### PR TITLE
fix: 랜딩페이지 반응형 개선 & Next middleware 로직 수정

### DIFF
--- a/src/app/_components/LandingFeatFirst.jsx
+++ b/src/app/_components/LandingFeatFirst.jsx
@@ -4,7 +4,7 @@ export default function LandingFeatFirst() {
     <div>
       <section className="bg-landing-feat1 flex flex-col justify-start w-full h-[440px] sm:h-[707px] md:h-[800px]">
         {/* 텍스트 */}
-        <div className="flex flex-col items-start justify-center mt-[67px] ml-[32px] sm:mt-[110px] sm:ml-[61px] md:mt-[138px] md:ml-[428px] w-full gap-3 sm:gap-[14px]">
+        <div className="flex flex-col items-start justify-center mt-[67px] ml-[32px] sm:mt-[110px] sm:ml-[61px] md:mt-[138px] md:ml-[370px] w-full gap-3 sm:gap-[14px]">
           <h1 className="text-white font-bold text-[20px] sm:text-4xl">
             포인트로 <span className="text-main">안전하게 거래</span>하세요
           </h1>

--- a/src/app/_components/LandingFeatSecond.jsx
+++ b/src/app/_components/LandingFeatSecond.jsx
@@ -4,7 +4,7 @@ export default function LandingFeatSecond() {
     <div>
       <section className="bg-landing-feat2 flex flex-col justify-start w-full h-[519px] sm:h-[776px] md:h-[800px]">
         {/* 텍스트 */}
-        <div className="flex flex-col items-start justify-center mt-[67px] ml-[32px] sm:mt-[113px] sm:ml-[61px] md:mt-[128px] md:ml-[428px] w-full gap-3 sm:gap-[14px]">
+        <div className="flex flex-col items-start justify-center mt-[67px] ml-[32px] sm:mt-[113px] sm:ml-[61px] md:mt-[128px] md:ml-[370px] w-full gap-3 sm:gap-[14px]">
           <h1 className="text-white font-bold text-[20px] sm:text-4xl">
             알림으로 보다 <span className="text-blue">빨라진 거래</span>
           </h1>

--- a/src/app/_components/LandingFeatThird.jsx
+++ b/src/app/_components/LandingFeatThird.jsx
@@ -4,8 +4,8 @@ export default function LandingFeatThird() {
     <div>
       <section className="bg-landing-feat3 flex flex-col justify-start w-full h-[390px] sm:h-[667px] md:h-[900px]">
         {/* 텍스트 */}
-        <div className="flex flex-col items-start justify-center mt-[67px] ml-[32px] sm:mt-[110px] sm:ml-[61px] md:mt-[133px] md:ml-[428px] w-full gap-3 sm:gap-[14px]">
-          <h1 className="text-white text-center text-[20px] h-12 font-bold sm:h-[96px] sm:text-[40px]">
+        <div className="flex flex-col items-start justify-center mt-[67px] ml-[32px] sm:mt-[110px] sm:ml-[61px] md:mt-[115px] md:ml-[370px] w-full gap-3 sm:gap-[14px]">
+          <h1 className="text-white text-center text-[20px] font-bold sm:text-[40px]">
             랜덤 상자로 <span className="text-main">포인트 받자!</span>
             🎉
           </h1>

--- a/src/app/_components/LandingHero.jsx
+++ b/src/app/_components/LandingHero.jsx
@@ -6,10 +6,10 @@ import Image from "next/image";
 
 export default function LandingHero() {
   return (
-    <section className="flex flex-col items-center bg-landing-hero max-w-[1798px] rounded-3xl mx-[16px] mb-[12px] mt-[33px] sm:mx-[23px] sm:mb-[0px] sm:mt-[23px] md:mx-[58px] md:mt-[13px] h-[412px] sm:h-[722px] md:h-[1088px]">
+    <section className="flex flex-col items-center max-width-[1088px] bg-landing-hero rounded-3xl mx-[16px] mb-[12px] mt-[33px] sm:mx-[23px] sm:mb-[0px] sm:mt-[23px] md:mt-[13px] h-[412px] sm:h-[722px] md:h-[1088px] md:mx-0">
       {/* 텍스트 & CTA 버튼 */}
       <div className="flex flex-col items-center justify-center h-full mt-[40px]">
-        <div className="flex flex-col gap-4  md:gap-10 items-center md:py-10 text-center">
+        <div className="flex flex-col items-center md:py-10 text-center">
           <div className="relative hidden sm:block sm:w-[138px] sm:h-[25px] sm:mb-[23px]">
             <Image
               src={logoImg}

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -69,7 +69,7 @@ export default function LandingPage() {
       </div> */}
 
       {/* 랜딩페이지 전체 */}
-      <div className="max-w-[744px] mx-auto overflow-x-hidden sm:max-w-[1480px] md:max-w-full">
+      <div className="mx-auto overflow-x-hidden max-w-[1798px] md:px-[32.5px]">
         <LandingHero />
         <LandingFeatFirst />
         <LandingFeatSecond />

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -23,7 +23,7 @@ export function middleware(request) {
   const { pathname } = request.nextUrl;
   const accessToken = request.cookies.get("accessToken")?.value;
   const refreshToken = request.cookies.get("refreshToken")?.value;
-  const isAuthenticated = Boolean(accessToken && refreshToken);
+  const isAuthenticated = Boolean(accessToken || refreshToken);
 
   // 로그인한 사용자가 auth 라우트에 접근하려고 할 때
   if (isAuthenticated && authRoutes.includes(pathname)) {


### PR DESCRIPTION
## 🔍️ 이 PR을 통해 해결하려는 문제가 무엇인가요?

> 어떤 기능을 구현한건지, 이슈 대응이라면 어떤 이슈인지 PR이 열리게 된 계기와 목적을 Reviewer 들이 쉽게 이해할 수 있도록 적어 주세요  
> 해당 작업을 파악하기 위한 개발 계획 문서, 피그마, QA 문서 등의 링크를 첨부해주세요.
- 랜딩페이지 히어로 부분 디자인 개선
- 사용자가 로그인한 상태이지만 access token이 만료된 경우, Next middleware에서 보호된 라우트로 이동 시 access token과 refresh token이 모두 없는 것으로 간주되어 로그인 페이지로 리다이렉트되는 문제가 있었습니다.  
- 실제로는 refresh token이 남아있어 토큰 갱신이 가능한 상태였지만, 토큰 갱신 로직이 페이지 내부에서 `cookieFetch`를 통해 작동하기 때문에, middleware에서 먼저 이동을 차단하면서 유저가 갱신 기회를 얻지 못하는 상황이 발생했습니다.

---

## ✨ 이 PR에서 핵심적으로 변경된 사항은 무엇일까요?

> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요

- QA 기준에 따라 랜딩 페이지의 반응형 스타일을 개선했습니다.  
- Next middleware 로직을 개선하여 `access token || refresh token` 중 하나라도 존재하면 인증된 사용자로 간주하도록 변경했습니다.  
  이로 인해 access token이 만료되었더라도 refresh token이 유효한 경우, 보호된 페이지 접근이 가능해졌고, 해당 페이지 내에서 자동으로 토큰이 갱신되도록 흐름이 자연스럽게 이어지게 했습니다.

---

## 🔖 핵심 변경 사항 외에 추가적으로 변경된 부분이 있나요?

> 없으면 "없음" 이라고 기재해 주세요

- 없음

---

## 🙏 Reviewer 분들이 이런 부분을 신경써서 봐 주시면 좋겠어요

> 개발 과정에서 다른 분들의 의견은 어떠한지 궁금했거나 크로스 체크가 필요하다고 느껴진 코드가 있다면 남겨주세요

- 

---

## 🩺 이 PR에서 테스트 혹은 검증이 필요한 부분이 있을까요?

> 테스트가 필요한 항목이나 테스트 코드가 추가되었다면 함께 적어주세요

- 

---

## 📝 CheckList

- [ ]
- [ ]

---

## 🔗 Reference

- `Next middleware` 변경 관련 코드:

  ```js
  const accessToken = request.cookies.get("accessToken")?.value;
  const refreshToken = request.cookies.get("refreshToken")?.value;
  const isAuthenticated = Boolean(accessToken || refreshToken);
